### PR TITLE
Switch to colorette

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -2,7 +2,8 @@
   "typescript": {
     "semiColons": "asi",
     "lineWidth": 120,
-    "trailingCommas": "never"
+    "trailingCommas": "never",
+    "quoteStyle": "preferDouble"
   },
   "json": {
     "trailingCommas": "never"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.6",
       "license": "ISC",
       "dependencies": {
-        "chalk": "4.1.1",
+        "colorette": "^2.0.20",
         "diff": "5.0.0"
       },
       "devDependencies": {
@@ -1291,6 +1291,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1386,6 +1387,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
       "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -1431,6 +1433,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1443,13 +1446,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -2243,6 +2246,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3219,6 +3223,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.6",
       "license": "ISC",
       "dependencies": {
-        "colorette": "^2.0.20",
+        "colorette": "2.0.20",
         "diff": "5.0.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "update": "npm-check-updates -u && npm install"
   },
   "dependencies": {
-    "chalk": "4.1.1",
+    "colorette": "2.0.20",
     "diff": "5.0.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import chalk from "chalk"
+import * as colorette from "colorette"
 import * as diff from "diff"
 
 /**
@@ -103,15 +103,15 @@ export function wordsWithSpace(
 //   }
 // }
 
-/** returns the chalk function to render the given diff part */
-function getColor(part: diff.Change) {
+/** returns the color function to render the given diff part */
+function getColor(part: diff.Change): colorette.Color {
   if (part.added) {
-    return chalk.green
+    return colorette.green
   }
   if (part.removed) {
-    return chalk.red
+    return colorette.red
   }
-  return chalk.grey
+  return colorette.gray
 }
 
 /** renders the given diff into a string containing Bash colors */

--- a/test/chars.test.ts
+++ b/test/chars.test.ts
@@ -15,7 +15,7 @@ suite("assertNoDiff.chars()", function () {
     const obj2 = "Captain Picard"
     const expected = `mismatching strings:
 
-${red("Je")}${green("C")}${gray("a")}${green("ptai")}${gray("n")}${red("- Luc")}${gray("Picard")}`
+${red("Je")}${green("C")}${gray("a")}${green("ptai")}${gray("n")}${red("-Luc")}${gray(" Picard")}`
     assert.throws(
       function () {
         assertNoDiff.chars(obj2, obj1)

--- a/test/chars.test.ts
+++ b/test/chars.test.ts
@@ -1,23 +1,23 @@
-import chalk from "chalk"
+import { green, red } from "colorette"
 import assert from "node:assert/strict"
 import { suite, test } from "node:test"
 import stripAnsi from "strip-ansi"
 import * as assertNoDiff from "../src/index"
 
-suite("assertNoDiff.chars()", function() {
-  test("matching data", function() {
+suite("assertNoDiff.chars()", function () {
+  test("matching data", function () {
     const data = "Jean-Luc Picard"
     assertNoDiff.chars(data, data)
   })
 
-  test("mismatching data", function() {
+  test("mismatching data", function () {
     const obj1 = "Jean-Luc Picard"
     const obj2 = "Captain Picard"
-    const expected = chalk`mismatching strings:
+    const expected = `mismatching strings:
 
-{red Je}{green C}{grey a}{green ptai}{grey n}{red -Luc}{grey  Picard}`
+${red("Je")}{ green("C") }{ grey a }{ green ptai }{ grey n }{ red - Luc}{ grey  Picard }`
     assert.throws(
-      function() {
+      function () {
         assertNoDiff.chars(obj2, obj1)
       },
       new Error(expected),
@@ -25,32 +25,32 @@ suite("assertNoDiff.chars()", function() {
     )
   })
 
-  test("no expected value", function() {
-    assert.throws(function() {
-      // @ts-ignore: intentional call without second argument
-      assertNoDiff.chars("foo")
-    }, new Error("AssertNoDiff: expected value not provided"))
-  })
+  // test("no expected value", function () {
+  //   assert.throws(function () {
+  //     // @ts-ignore: intentional call without second argument
+  //     assertNoDiff.chars("foo")
+  //   }, new Error("AssertNoDiff: expected value not provided"))
+  // })
 
-  test("no actual value", function() {
-    assert.throws(function() {
-      // @ts-ignore: intentional call without arguments
-      assertNoDiff.chars()
-    }, new Error("AssertNoDiff: actual value not provided"))
-  })
+  // test("no actual value", function () {
+  //   assert.throws(function () {
+  //     // @ts-ignore: intentional call without arguments
+  //     assertNoDiff.chars()
+  //   }, new Error("AssertNoDiff: actual value not provided"))
+  // })
 
-  test("providing a custom message", function() {
-    try {
-      assertNoDiff.chars("one", "two", "custom message")
-    } catch (e) {
-      const stripped = stripAnsi(e.message)
-      assert.equal(stripped, "custom message:\n\ntwone")
-      return
-    }
-    throw new Error("assertNoDiff.chars didn't throw")
-  })
+  // test("providing a custom message", function () {
+  //   try {
+  //     assertNoDiff.chars("one", "two", "custom message")
+  //   } catch (e) {
+  //     const stripped = stripAnsi(e.message)
+  //     assert.equal(stripped, "custom message:\n\ntwone")
+  //     return
+  //   }
+  //   throw new Error("assertNoDiff.chars didn't throw")
+  // })
 
-  test("diffing against empty strings", function() {
-    assertNoDiff.chars("", "")
-  })
+  // test("diffing against empty strings", function () {
+  //   assertNoDiff.chars("", "")
+  // })
 })

--- a/test/chars.test.ts
+++ b/test/chars.test.ts
@@ -20,8 +20,7 @@ ${red("Je")}${green("C")}${gray("a")}${green("ptai")}${gray("n")}${red("-Luc")}$
       function() {
         assertNoDiff.chars(obj2, obj1)
       },
-      new Error(expected),
-      "should throw color-coded diff"
+      new Error(expected)
     )
   })
 

--- a/test/chars.test.ts
+++ b/test/chars.test.ts
@@ -1,4 +1,4 @@
-import { green, red } from "colorette"
+import { green, red, gray } from "colorette"
 import assert from "node:assert/strict"
 import { suite, test } from "node:test"
 import stripAnsi from "strip-ansi"
@@ -15,7 +15,7 @@ suite("assertNoDiff.chars()", function () {
     const obj2 = "Captain Picard"
     const expected = `mismatching strings:
 
-${red("Je")}{ green("C") }{ grey a }{ green ptai }{ grey n }{ red - Luc}{ grey  Picard }`
+${red("Je")}${green("C")}${gray("a")}${green("ptai")}${gray("n")}${red("- Luc")}${gray("Picard")}`
     assert.throws(
       function () {
         assertNoDiff.chars(obj2, obj1)

--- a/test/chars.test.ts
+++ b/test/chars.test.ts
@@ -1,23 +1,23 @@
-import { green, red, gray } from "colorette"
+import { gray, green, red } from "colorette"
 import assert from "node:assert/strict"
 import { suite, test } from "node:test"
 import stripAnsi from "strip-ansi"
 import * as assertNoDiff from "../src/index"
 
-suite("assertNoDiff.chars()", function () {
-  test("matching data", function () {
+suite("assertNoDiff.chars()", function() {
+  test("matching data", function() {
     const data = "Jean-Luc Picard"
     assertNoDiff.chars(data, data)
   })
 
-  test("mismatching data", function () {
+  test("mismatching data", function() {
     const obj1 = "Jean-Luc Picard"
     const obj2 = "Captain Picard"
     const expected = `mismatching strings:
 
 ${red("Je")}${green("C")}${gray("a")}${green("ptai")}${gray("n")}${red("-Luc")}${gray(" Picard")}`
     assert.throws(
-      function () {
+      function() {
         assertNoDiff.chars(obj2, obj1)
       },
       new Error(expected),
@@ -25,32 +25,32 @@ ${red("Je")}${green("C")}${gray("a")}${green("ptai")}${gray("n")}${red("-Luc")}$
     )
   })
 
-  // test("no expected value", function () {
-  //   assert.throws(function () {
-  //     // @ts-ignore: intentional call without second argument
-  //     assertNoDiff.chars("foo")
-  //   }, new Error("AssertNoDiff: expected value not provided"))
-  // })
+  test("no expected value", function() {
+    assert.throws(function() {
+      // @ts-ignore: intentional call without second argument
+      assertNoDiff.chars("foo")
+    }, new Error("AssertNoDiff: expected value not provided"))
+  })
 
-  // test("no actual value", function () {
-  //   assert.throws(function () {
-  //     // @ts-ignore: intentional call without arguments
-  //     assertNoDiff.chars()
-  //   }, new Error("AssertNoDiff: actual value not provided"))
-  // })
+  test("no actual value", function() {
+    assert.throws(function() {
+      // @ts-ignore: intentional call without arguments
+      assertNoDiff.chars()
+    }, new Error("AssertNoDiff: actual value not provided"))
+  })
 
-  // test("providing a custom message", function () {
-  //   try {
-  //     assertNoDiff.chars("one", "two", "custom message")
-  //   } catch (e) {
-  //     const stripped = stripAnsi(e.message)
-  //     assert.equal(stripped, "custom message:\n\ntwone")
-  //     return
-  //   }
-  //   throw new Error("assertNoDiff.chars didn't throw")
-  // })
+  test("providing a custom message", function() {
+    try {
+      assertNoDiff.chars("one", "two", "custom message")
+    } catch (e) {
+      const stripped = stripAnsi(e.message)
+      assert.equal(stripped, "custom message:\n\ntwone")
+      return
+    }
+    throw new Error("assertNoDiff.chars didn't throw")
+  })
 
-  // test("diffing against empty strings", function () {
-  //   assertNoDiff.chars("", "")
-  // })
+  test("diffing against empty strings", function() {
+    assertNoDiff.chars("", "")
+  })
 })

--- a/test/json.test.ts
+++ b/test/json.test.ts
@@ -1,4 +1,4 @@
-import chalk from "chalk"
+import { gray, green, red } from "colorette"
 import assert from "node:assert/strict"
 import { suite, test } from "node:test"
 import stripAnsi from "strip-ansi"
@@ -13,12 +13,17 @@ suite("assertNoDiff.json", function() {
   test("mismatching data", function() {
     const obj1 = { firstName: "Jean-Luc", lastName: "Picard" }
     const obj2 = { firstName: "Captain", lastName: "Picard" }
-    const expected = chalk`mismatching objects:
+    const expected = `mismatching objects:
 
-{grey \{\n}{red   "firstName": "Jean-Luc",\n}{green   "firstName": "Captain",\n}{grey   "lastName": "Picard"\n\}}`
-    assert.throws(function() {
-      assertNoDiff.json(obj2, obj1)
-    }, new Error(expected))
+${gray("{\n")}${red("  \"firstName\": \"Jean-Luc\",\n")}${green("  \"firstName\": \"Captain\",\n")}${
+      gray("  \"lastName\": \"Picard\"\n}")
+    }`
+    assert.throws(
+      function() {
+        assertNoDiff.json(obj2, obj1)
+      },
+      new Error(expected)
+    )
   })
 
   test("no expected value", function() {

--- a/test/json.test.ts
+++ b/test/json.test.ts
@@ -15,8 +15,8 @@ suite("assertNoDiff.json", function() {
     const obj2 = { firstName: "Captain", lastName: "Picard" }
     const expected = `mismatching objects:
 
-${gray("{\n")}${red("  \"firstName\": \"Jean-Luc\",\n")}${green("  \"firstName\": \"Captain\",\n")}${
-      gray("  \"lastName\": \"Picard\"\n}")
+${gray("{\n")}${red('  "firstName": "Jean-Luc",\n')}${green('  "firstName": "Captain",\n')}${
+      gray('  "lastName": "Picard"\n}')
     }`
     assert.throws(
       function() {
@@ -45,7 +45,7 @@ ${gray("{\n")}${red("  \"firstName\": \"Jean-Luc\",\n")}${green("  \"firstName\"
       assertNoDiff.json({ a: 1 }, { a: 2 }, "custom message")
     } catch (e) {
       const stripped = stripAnsi(e.message)
-      assert.equal(stripped, "custom message:\n\n{\n  \"a\": 2\n  \"a\": 1\n}")
+      assert.equal(stripped, 'custom message:\n\n{\n  "a": 2\n  "a": 1\n}')
       return
     }
     throw new Error("assertNoDiff.json didn't throw")

--- a/test/trimmed-lines.test.ts
+++ b/test/trimmed-lines.test.ts
@@ -1,16 +1,16 @@
-import chalk from "chalk"
+import { gray, green, red } from "colorette"
 import assert from "node:assert/strict"
 import { suite, test } from "node:test"
 import stripAnsi from "strip-ansi"
 import * as assertNoDiff from "../src/index"
 
-suite("assertNoDiff.trimmedLines", function() {
-  test("matching data", function() {
+suite("assertNoDiff.trimmedLines", function () {
+  test("matching data", function () {
     const data = "Jean-Luc Picard"
     assertNoDiff.trimmedLines(data, data)
   })
 
-  test("matching data with surrounding whitespace", function() {
+  test("matching data with surrounding whitespace", function () {
     const obj1 = "foo"
     const obj2 = "  foo  "
     assertNoDiff.trimmedLines(
@@ -20,33 +20,33 @@ suite("assertNoDiff.trimmedLines", function() {
     )
   })
 
-  test("mismatching data", function() {
+  test("mismatching data", function () {
     const obj1 = "Jean-Luc\nPicard"
     const obj2 = "Captain\nPicard"
 
-    const expected = chalk`mismatching lines:
+    const expected = `mismatching lines:
 
-{red Jean-Luc\n}{green Captain\n}{grey Picard}`
-    assert.throws(function() {
+${red("Jean-Luc\n")}${green("Captain\n")}${gray("Picard")}`
+    assert.throws(function () {
       assertNoDiff.trimmedLines(obj2, obj1)
     }, new Error(expected))
   })
 
-  test("no expected value", function() {
-    assert.throws(function() {
+  test("no expected value", function () {
+    assert.throws(function () {
       // @ts-ignore
       assertNoDiff.trimmedLines("foo")
     }, new Error("AssertNoDiff: expected value not provided"))
   })
 
-  test("no actual value", function() {
-    assert.throws(function() {
+  test("no actual value", function () {
+    assert.throws(function () {
       // @ts-ignore
       assertNoDiff.trimmedLines()
     }, new Error("AssertNoDiff: actual value not provided"))
   })
 
-  test("custom error message", function() {
+  test("custom error message", function () {
     try {
       assertNoDiff.trimmedLines("one", "two", "custom message")
     } catch (e) {
@@ -57,7 +57,7 @@ suite("assertNoDiff.trimmedLines", function() {
     throw new Error("assertNoDiff.trimmedLines didn't throw")
   })
 
-  test("diffing empty strings", function() {
+  test("diffing empty strings", function () {
     assertNoDiff.trimmedLines("", "", "should allow diffing empty strings")
   })
 })

--- a/test/trimmed-lines.test.ts
+++ b/test/trimmed-lines.test.ts
@@ -4,13 +4,13 @@ import { suite, test } from "node:test"
 import stripAnsi from "strip-ansi"
 import * as assertNoDiff from "../src/index"
 
-suite("assertNoDiff.trimmedLines", function () {
-  test("matching data", function () {
+suite("assertNoDiff.trimmedLines", function() {
+  test("matching data", function() {
     const data = "Jean-Luc Picard"
     assertNoDiff.trimmedLines(data, data)
   })
 
-  test("matching data with surrounding whitespace", function () {
+  test("matching data with surrounding whitespace", function() {
     const obj1 = "foo"
     const obj2 = "  foo  "
     assertNoDiff.trimmedLines(
@@ -20,33 +20,33 @@ suite("assertNoDiff.trimmedLines", function () {
     )
   })
 
-  test("mismatching data", function () {
+  test("mismatching data", function() {
     const obj1 = "Jean-Luc\nPicard"
     const obj2 = "Captain\nPicard"
 
     const expected = `mismatching lines:
 
 ${red("Jean-Luc\n")}${green("Captain\n")}${gray("Picard")}`
-    assert.throws(function () {
+    assert.throws(function() {
       assertNoDiff.trimmedLines(obj2, obj1)
     }, new Error(expected))
   })
 
-  test("no expected value", function () {
-    assert.throws(function () {
+  test("no expected value", function() {
+    assert.throws(function() {
       // @ts-ignore
       assertNoDiff.trimmedLines("foo")
     }, new Error("AssertNoDiff: expected value not provided"))
   })
 
-  test("no actual value", function () {
-    assert.throws(function () {
+  test("no actual value", function() {
+    assert.throws(function() {
       // @ts-ignore
       assertNoDiff.trimmedLines()
     }, new Error("AssertNoDiff: actual value not provided"))
   })
 
-  test("custom error message", function () {
+  test("custom error message", function() {
     try {
       assertNoDiff.trimmedLines("one", "two", "custom message")
     } catch (e) {
@@ -57,7 +57,7 @@ ${red("Jean-Luc\n")}${green("Captain\n")}${gray("Picard")}`
     throw new Error("assertNoDiff.trimmedLines didn't throw")
   })
 
-  test("diffing empty strings", function () {
+  test("diffing empty strings", function() {
     assertNoDiff.trimmedLines("", "", "should allow diffing empty strings")
   })
 })

--- a/test/words-with-space.test.ts
+++ b/test/words-with-space.test.ts
@@ -1,34 +1,34 @@
-import chalk from "chalk"
+import { gray, green, red } from "colorette"
 import assert from "node:assert/strict"
 import { suite, test } from "node:test"
 import stripAnsi from "strip-ansi"
 import * as assertNoDiff from "../src/index"
 
-suite("assertNoDiff.wordsWithSpace", function() {
-  test("matching data", function() {
+suite("assertNoDiff.wordsWithSpace", function () {
+  test("matching data", function () {
     const data = "Jean-Luc Picard"
     assertNoDiff.wordsWithSpace(data, data)
   })
 
-  test("mismatching data", function() {
+  test("mismatching data", function () {
     const obj1 = "Jean-Luc Picard"
     const obj2 = "Captain Picard"
-    const expected = chalk`mismatching words:
+    const expected = `mismatching words:
 
-{red Jean-Luc}{green Captain}{grey  Picard}`
-    assert.throws(function() {
+${red("Jean-Luc")}${green("Captain")}${gray(" Picard")}`
+    assert.throws(function () {
       assertNoDiff.wordsWithSpace(obj2, obj1)
     }, new Error(expected))
   })
 
-  test("extra whitespace", function() {
+  test("extra whitespace", function () {
     const obj1 = "foo bar"
     const obj2 = " foo bar"
-    const expected = chalk`mismatching words:
+    const expected = `mismatching words:
 
-{green  }{grey foo bar}`
+${green(" ")}${gray("foo bar")}`
     assert.throws(
-      function() {
+      function () {
         assertNoDiff.wordsWithSpace(obj2, obj1)
       },
       new Error(expected),
@@ -36,21 +36,21 @@ suite("assertNoDiff.wordsWithSpace", function() {
     )
   })
 
-  test("no expected value", function() {
-    assert.throws(function() {
+  test("no expected value", function () {
+    assert.throws(function () {
       // @ts-ignore
       assertNoDiff.wordsWithSpace("foo")
     }, new Error("AssertNoDiff: expected value not provided"))
   })
 
-  test("no actual value", function() {
-    assert.throws(function() {
+  test("no actual value", function () {
+    assert.throws(function () {
       // @ts-ignore
       assertNoDiff.wordsWithSpace()
     }, new Error("AssertNoDiff: actual value not provided"))
   })
 
-  test("custom error message", function() {
+  test("custom error message", function () {
     try {
       assertNoDiff.wordsWithSpace("one", "two", "custom message")
     } catch (e) {
@@ -61,7 +61,7 @@ suite("assertNoDiff.wordsWithSpace", function() {
     throw new Error("assertNoDiff.wordsWithSpace didn't throw")
   })
 
-  test("empty strings", function() {
+  test("empty strings", function () {
     assertNoDiff.wordsWithSpace("", "", "should allow diffing empty strings")
   })
 })

--- a/test/words-with-space.test.ts
+++ b/test/words-with-space.test.ts
@@ -4,31 +4,31 @@ import { suite, test } from "node:test"
 import stripAnsi from "strip-ansi"
 import * as assertNoDiff from "../src/index"
 
-suite("assertNoDiff.wordsWithSpace", function () {
-  test("matching data", function () {
+suite("assertNoDiff.wordsWithSpace", function() {
+  test("matching data", function() {
     const data = "Jean-Luc Picard"
     assertNoDiff.wordsWithSpace(data, data)
   })
 
-  test("mismatching data", function () {
+  test("mismatching data", function() {
     const obj1 = "Jean-Luc Picard"
     const obj2 = "Captain Picard"
     const expected = `mismatching words:
 
 ${red("Jean-Luc")}${green("Captain")}${gray(" Picard")}`
-    assert.throws(function () {
+    assert.throws(function() {
       assertNoDiff.wordsWithSpace(obj2, obj1)
     }, new Error(expected))
   })
 
-  test("extra whitespace", function () {
+  test("extra whitespace", function() {
     const obj1 = "foo bar"
     const obj2 = " foo bar"
     const expected = `mismatching words:
 
 ${green(" ")}${gray("foo bar")}`
     assert.throws(
-      function () {
+      function() {
         assertNoDiff.wordsWithSpace(obj2, obj1)
       },
       new Error(expected),
@@ -36,21 +36,21 @@ ${green(" ")}${gray("foo bar")}`
     )
   })
 
-  test("no expected value", function () {
-    assert.throws(function () {
+  test("no expected value", function() {
+    assert.throws(function() {
       // @ts-ignore
       assertNoDiff.wordsWithSpace("foo")
     }, new Error("AssertNoDiff: expected value not provided"))
   })
 
-  test("no actual value", function () {
-    assert.throws(function () {
+  test("no actual value", function() {
+    assert.throws(function() {
       // @ts-ignore
       assertNoDiff.wordsWithSpace()
     }, new Error("AssertNoDiff: actual value not provided"))
   })
 
-  test("custom error message", function () {
+  test("custom error message", function() {
     try {
       assertNoDiff.wordsWithSpace("one", "two", "custom message")
     } catch (e) {
@@ -61,7 +61,7 @@ ${green(" ")}${gray("foo bar")}`
     throw new Error("assertNoDiff.wordsWithSpace didn't throw")
   })
 
-  test("empty strings", function () {
+  test("empty strings", function() {
     assertNoDiff.wordsWithSpace("", "", "should allow diffing empty strings")
   })
 })


### PR DESCRIPTION
Colorette is smaller and used by my other TS libraries --> less bloat in node_modules.
Also, the unit tests now describe precisely the expected format. The chalk string hack was pretty unintuitive.